### PR TITLE
Add `.mjs` as generated / kept files

### DIFF
--- a/packages/rescript-relay/language-plugin/src/index.ts
+++ b/packages/rescript-relay/language-plugin/src/index.ts
@@ -31,8 +31,8 @@ module.exports = () => ({
   formatModule: formatGeneratedModule,
   findGraphQLTags: find,
   isGeneratedFile: (fileName: string) =>
-    fileName.endsWith("_graphql.res") || fileName.endsWith(".bs.js"),
-  keepExtraFile: (fileName: string) => fileName.endsWith(".bs.js"),
+    fileName.endsWith("_graphql.res") || fileName.endsWith(".bs.js") || fileName.endsWith(".mjs"),
+  keepExtraFile: (fileName: string) => fileName.endsWith(".bs.js") || fileName.endsWith(".mjs"),
   getFileFilter,
   getModuleName: (operationName: string) => `${operationName}_graphql`,
 });


### PR DESCRIPTION
Through a series of interactions that I don't completely understand, @ryyppy helped me upgrade my rescript-nextjs app to webpack5 (which I needed for reasons I've since forgot). In the process, we had to change the file extension to `.mjs` so that nextjs/webpack would be happy with the generated JavaScript (possibly something around `import` vs `require`).

Long story short, it's working on that side, but when I added rescript-relay, it kept deleting the generated files. It was quite difficult to track down, because *sometimes* nextjs would move fast enough to load the file, and other times it would complain the file didn't exist.

This change adds `.mjs` to both the `isGeneratedFile` and `keepExtraFile` predicates. I suspect this should be fine, since very few people manually write `.mjs` files, and there's no real reason they should end up in the `__generated__` folder anyway.